### PR TITLE
Correct figure 2 file path in BP11 examples.md

### DIFF
--- a/SBOL/best-practices/BP011/examples.md
+++ b/SBOL/best-practices/BP011/examples.md
@@ -10,7 +10,7 @@ Figure 1 and Figure 2 illustrate two ways of representing the composite part BBa
 
 **Figure 1:** Composite part example UML diagram with `Locations`. 
 
-![composite_part](images/composite_part_example_1.png "Composite part example UML diagram with Locations")
+![composite_part](images/composite_part_example_2.png "Composite part example UML diagram with Locations")
 
 **Figure 2:** Composite part example UML diagram with `Constraints`.
 


### PR DESCRIPTION
Correct typo in picture file name for figure 2 in BP11 examples. Picture for figure 1 was linked instead of picture for figure 2.