### PR TITLE
adding backbone core 

### DIFF
--- a/SBOL/best-practices/BP011/README.md
+++ b/SBOL/best-practices/BP011/README.md
@@ -17,6 +17,8 @@ This specification and set of practices for representation of parts and devices 
 
 * **Backbone**: A DNA construct into which parts are intended to be inserted at one or more designated insertion sites, in order to meet the requirements of an assembly. Precisely one part can be inserted at any given insertion site. In many cases, a backbone will be a circular plasmid with precisly one insertion site, but other types of vector are possible as well, such as linear plasmids, viral replicons, or non-replicating flanking adapters.
 
+  * **Backbone Core**: Any backbone that is not designed with reference to an assembly. This is a linear part that may become circular after the assembly, common features that are useful to identify on backbone cores are origin of replication and antibiotic resistance. The distinction is in whether an assembly is referenced in the design (i.e., an open backbone can be transformed into a backbone core by stripping associated assembly information such as flanking scars os fusion sites).
+
   * **Drop-Out Sequence**: A portion of a backbone at an insertion site that is removed when a part is inserted at that site. Some backbones include drop-out parts while others do not.
 
   * **Part Insert**: A part, plus any 5' and 3' flanking sequences, that is placed into a designated insertion site of a backbone.  


### PR DESCRIPTION
When creating backbones, parts in backbone and plasmids in general the notion of backbone core is useful to refer and mark repeated elements in designs. 
For example, in the [MoClo kit](https://www.addgene.org/kits/densmore-cidar-moclo/#kit-contents) we have DVA_AE and DVA_AF these are two different backbones that have the same drop-out and backbone core and just differ in the fusion sites. See issue #42 

In the Example 1 image we have a promoter part flanked by assembly scars and a backbone core would correspond to the circular glyph.

![backbone_core_example](https://github.com/user-attachments/assets/48c319bd-0f5d-4035-b030-708a26b12ad7)
Example 1

This representations works for circular plasmids but not for linear. Another alternative is to inform the backbone core using regions and leave the circular indicators as context, not referring any component with them, just reflecting the circular type as in example 2 and 3 images.

![bb_core2](https://github.com/user-attachments/assets/6ec55e9a-ad33-458f-b8e2-c90f0bd6bd95)
Example 2

![bb_core3](https://github.com/user-attachments/assets/546e6fd1-20c5-4f36-8af0-bbddb7281c4f)
Example 3

I would like to open the discussion and get feedback from the community.